### PR TITLE
Accessibility and state management

### DIFF
--- a/src/cljs/checker/views.cljs
+++ b/src/cljs/checker/views.cljs
@@ -108,29 +108,31 @@ var freecoins_cvq = [
   (let [free-ph  "請輸入 FREECOINS_後五碼，如 17785 "
         memo-ph  "選填額外資訊，如：促銷註記"]
     [:main.helvetica.dark-gray.ml3
-     [:h1 "CPA CV Tag Format Generator"]
-     [:div.dt--fixed
-      [:div.dt-row
-       [:label.dtc {:for "switch"} "任務類型: "] [switch "switch" r-switch]]
-      [:div.dt-row
-       [:label.dtc {:for "freecoin"} "Freecoins 參數: "]
-       [common-input "freecoin" free-atom free-ph]
-       [:div.dtc]]
-      [div-middle @r-switch]
-      [:div.dt-row
-       [:label.dtc {:for "memo"} "Memo: "]
-       [common-input "memo" memo-atom memo-ph]
-       [:div.dtc "max 255 bytes"]]]
-     [:div
-      [:div]
+     [:form
+      [:h1 "CPA CV Tag Format Generator"]
+      [:div.dt--fixed
+       [:div.dt-row
+        [:label.dtc {:for "switch"} "任務類型: "] [switch "switch" r-switch]]
+       [:div.dt-row
+        [:label.dtc {:for "freecoin"} "Freecoins 參數: "]
+        [common-input "freecoin" free-atom free-ph]
+        [:div.dtc]]
+       [div-middle @r-switch]
+       [:div.dt-row
+        [:label.dtc {:for "memo"} "Memo: "]
+        [common-input "memo" memo-atom memo-ph]
+        [:div.dtc "max 255 bytes"]]]
       [:div
-       [:input {:type "button" :value "generate"
-                :on-click (fn [e]
-                            (prn (-> e .-target .-value))
-                            (reset! cv-atom
-                                    (replace-tmpl cv-template
-                                                  @free-atom @order-atom @item-atom
-                                                  @price-atom @memo-atom)))}]]]
+       [:div]
+       [:div
+        [:input {:type "submit" :value "generate"
+                 :on-click (fn [e]
+                             (.. e preventDefault)
+                             (prn (-> e .-target .-value))
+                             (reset! cv-atom
+                                     (replace-tmpl cv-template
+                                                   @free-atom @order-atom @item-atom
+                                                   @price-atom @memo-atom)))}]]]]
      [:div.flex.items-center
       [:label.mr5
        {:for "code"}

--- a/src/cljs/checker/views.cljs
+++ b/src/cljs/checker/views.cljs
@@ -81,6 +81,7 @@ var freecoins_cvq = [
 
 (defn switch [id]
   [:select {:id        id
+            :value     (:r-switch @state)
             :on-change handle-switch-change}
    [:option {:value "buy"} "購買型任務"]
    [:option {:value "non-buy"} "非購買型任務"]])
@@ -89,6 +90,7 @@ var freecoins_cvq = [
   [:input.dtc {:id          id
                :size        60
                :placeholder ph
+               :value       (entity-key @state)
                :on-change   (partial handle-input-change entity-key)}])
 
 (defn ph-switch-order [s]


### PR DESCRIPTION
Hi @humorless, 

I think this project can benefit from these changes:

1. Prefer `<form>` for better accessibility, and 
2. Consolidate state into one single r/atom, also
3. Properly reflect the current form state on the input elements.

Item 3 above is mainly for dev use case because when shadow-cljs reloads the page, the inputs weren't reflecting the current values in the state.

I have a more detailed rationale written in the commit message. Please let me know what you think or if there's anything that requires clarification. Cheers! :)
